### PR TITLE
Makefile rearrangment, Coq -> Rocq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 *.vos
 *~
 .*.d
-**/Makefile.conf
-**/Makefile.coq
+**/Makefile.rocq
+**/Makefile.rocq.conf

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,17 @@
+all: Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+
+clean: _CoqProject
+	# We have to make the coq makefile in case it is missing
+	coq_makefile -f $< -o Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+	rm Makefile.rocq Makefile.rocq.conf
+
+Makefile.rocq: _CoqProject
+	coq_makefile -f $< -o $@
+
+.DEFAULT:
+	$(MAKE) Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+
+.PHONY: all clean

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,9 +1,0 @@
-all: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
-.PHONY: all
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-.DEFAULT: Makefile.coq
-	$(MAKE) -f Makefile.coq $@

--- a/examples/Makefile.common
+++ b/examples/Makefile.common
@@ -1,0 +1,17 @@
+all: Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+
+clean: _CoqProject
+	# We have to make the coq makefile in case it is missing
+	coq_makefile -f $< -o Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+	rm Makefile.rocq Makefile.rocq.conf
+
+Makefile.rocq: _CoqProject
+	coq_makefile -f $< -o $@
+
+.DEFAULT:
+	$(MAKE) Makefile.rocq
+	$(MAKE) -f Makefile.rocq $@
+
+.PHONY: all clean

--- a/examples/hott/Makefile
+++ b/examples/hott/Makefile
@@ -1,10 +1,1 @@
-all: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
-
-.PHONY: all
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-.DEFAULT: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
+../Makefile.common

--- a/examples/std/Makefile
+++ b/examples/std/Makefile
@@ -1,9 +1,1 @@
-all: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
-.PHONY: all
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-.DEFAULT: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
+../Makefile.common

--- a/hott/Makefile
+++ b/hott/Makefile
@@ -1,9 +1,1 @@
-all: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
-.PHONY: all
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-.DEFAULT: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
+../Makefile.common

--- a/std/Makefile
+++ b/std/Makefile
@@ -1,9 +1,1 @@
-all: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
-.PHONY: all
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-.DEFAULT: Makefile.coq
-	$(MAKE) -f Makefile.coq $@
+../Makefile.common


### PR DESCRIPTION
- Fixed putting custom targets to rocq project makefiles when the Makefile.rocq has not been previously built.
- Implemented `make clean` for projects, that also removes Makefile.rocq
- Temporary rocq makefiles are now named Makefile.rocq instead of Makefile.coq
- Makefiles for std and hott are symlinked to the same file, same for examples/std and examples/hott